### PR TITLE
feat: implemented ratelimiter for cards service via edgeserver customroutes

### DIFF
--- a/gatewayserver/pom.xml
+++ b/gatewayserver/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.3</version>
+		<version>3.5.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.nanaBank</groupId>
@@ -56,6 +56,13 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
     </dependency>
+    
+    <!--redis depedency (useful in rate limiter pattern)-->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+    </dependency>
+    
     
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/gatewayserver/src/main/resources/application.yml
+++ b/gatewayserver/src/main/resources/application.yml
@@ -18,6 +18,13 @@ spring:
      httpclient:
       connect-timeout: 1000
       response-timeout: 2s
+#redis config
+  data:
+   redis:
+    connect-timeout: 2s
+    host: localhost
+    port: 6379
+    timeout: 1s
 
 management:
  endpoints:


### PR DESCRIPTION
PR introduces ratelimiter pattern implementation in the gateway server to regulate the number of requests a user can send persecond/ timeframe 

## test
i set
int defaultReplenishRate =1,
int defaultBurstCapacity = 1,
int defaultRequestedTokens = 1
)
used apache bench mark to send 10 requests but in a sequence of 2 requests sent at atime

```
ab -n 10 -c 2 -v 3 http://localhost:8072/nanabank/cards/api/cards/contact-info

```

response
```
---
GET /nanabank/cards/api/cards/contact-info HTTP/1.0
Host: localhost:8072
User-Agent: ApacheBench/2.3
Accept: */*


---
LOG: header received:
HTTP/1.1 200 OK
transfer-encoding: chunked
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
Content-Type: application/json
Date: Thu, 25 Sep 2025 07:05:05 GMT
nanabank-correlation-id: 637d2219-a4ff-4196-80a8-5571ed32464b
X-Response-Time: 2025-09-25T03:04:55.053701123
connection: close


LOG: Response code = 200
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
LOG: header received:
HTTP/1.0 429 Too Many Requests
X-RateLimit-Remaining: 0
X-RateLimit-Requested-Tokens: 1
X-RateLimit-Burst-Capacity: 1
X-RateLimit-Replenish-Rate: 1
content-length: 0


WARNING: Response code not 2xx (429)
..done


Server Software:        
Server Hostname:        localhost
Server Port:            8072

Document Path:          /nanabank/cards/api/cards/contact-info
Document Length:        180 bytes

Concurrency Level:      2
Time taken for tests:   0.193 seconds
Complete requests:      10
Failed requests:        9
   (Connect: 0, Receive: 0, Length: 9, Exceptions: 0)
Non-2xx responses:      9
Total transferred:      2113 bytes
HTML transferred:       180 bytes
Requests per second:    51.71 [#/sec] (mean)
Time per request:       38.675 [ms] (mean)
Time per request:       19.338 [ms] (mean, across all concurrent requests)
Transfer rate:          10.67 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.0      0       0
Processing:     8   23  45.3      9     152
Waiting:        7   23  44.9      8     150
Total:          8   23  45.3      9     152

Percentage of the requests served within a certain time (ms)
  50%      9
  66%      9
  75%      9
  80%     12
  90%    152
  95%    152
  98%    152
  99%    152
 100%    152 (longest request)
```